### PR TITLE
 PayAPI-X Smart Contract for Pay-Per-Call API Monetization on Stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# PayAPI-X 🧾
+
+**PayAPI-X** is a Clarity smart contract that enables **pay-per-call API access** on the Stacks blockchain. It allows API service providers to monetize their off-chain APIs through micropayments in STX, and enables users to pay per request to gain access to these services.
+
+## 🔍 Overview
+
+- **Provider registration**: Service owners can register APIs and set per-call prices.
+- **Per-call access**: Users pay STX to access a specific API.
+- **Access verification**: A log of paid access is recorded on-chain and can be verified by external services or oracles.
+- **Use case**: Works with relays or gateways that listen to contract events and grant actual access to off-chain endpoints.
+
+---
+
+## 📦 Features
+
+- 🧩 API registration by providers
+- 💸 Pay-per-use micropayment system
+- 🔒 On-chain access log for auditing or off-chain validation
+- 🧾 STX is directly transferred from users to providers
+
+---
+
+## 💻 Contract Structure
+
+- `register-api(api-id, price)` – Registers an API endpoint with a price.
+- `pay-for-api(provider, api-id)` – Allows users to pay and log access.
+- `has-access(user, provider, api-id)` – Read-only function to check access.
+
+---
+
+## 🛠 Usage Example
+
+```clarity
+;; Provider registers an API with id 1 at price 10000 uSTX
+(register-api u1 u10000)
+
+;; User pays 10000 uSTX to access provider's API
+(pay-for-api 'SP123... u1)
+
+;; Off-chain service checks if user has paid
+(has-access 'SP456... 'SP123... u1)

--- a/contracts/payapi-x.clar
+++ b/contracts/payapi-x.clar
@@ -1,0 +1,66 @@
+(define-constant err-not-owner (err u100))
+(define-constant err-not-registered (err u101))
+(define-constant err-insufficient-payment (err u102))
+
+(define-data-var owner principal tx-sender)
+
+(define-map apis
+  {provider: principal, api-id: uint}
+  {
+    price: uint,
+    active: bool
+  }
+)
+
+(define-map access-log
+  {user: principal, provider: principal, api-id: uint}
+  {
+    timestamp: uint
+  }
+)
+
+;; Only owner can register new APIs
+(define-public (register-api (api-id uint) (price uint))
+  (begin
+    (if (is-eq tx-sender (var-get owner))
+        (begin
+          (map-set apis
+            {provider: tx-sender, api-id: api-id}
+            {price: price, active: true}
+          )
+          (ok true)
+        )
+        err-not-owner
+    )
+  )
+)
+
+;; Users pay per API access
+(define-public (pay-for-api (provider principal) (api-id uint) (amount uint))
+  (let
+    (
+      (api-info (map-get? apis {provider: provider, api-id: api-id}))
+    )
+    (match api-info api
+      (if (and (get active api) (>= amount (get price api)))
+          (match (stx-transfer? (get price api) tx-sender provider)
+            success (begin
+              (map-set access-log
+                {user: tx-sender, provider: provider, api-id: api-id}
+                {timestamp: stacks-block-height}
+              )
+              (ok true)
+            )
+            error (err u103)
+          )
+          err-insufficient-payment
+      )
+      err-not-registered
+    )
+  )
+)
+
+;; Read-only to check access
+(define-read-only (has-access (user principal) (provider principal) (api-id uint))
+  (is-some (map-get? access-log {user: user, provider: provider, api-id: api-id}))
+)


### PR DESCRIPTION
### Overview

This PR introduces the `payapi-x` smart contract — a decentralized micro-payment solution for monetizing API calls on the Stacks blockchain.

The contract enables service providers to:
- Register APIs with unique identifiers and pricing (in micro-STX)
- Receive per-call payments from users
- Track user access to API endpoints on-chain

### Features

- `register-api (api-id, price)`: Allows providers to register an API and set the price per call
- `pay-for-api (provider, api-id)`: Lets users pay for access to a specific API endpoint
- `has-access (user, provider, api-id)`: Read-only function to verify if a user has paid for a specific API

### Integration Use Case

This contract is designed for integration with off-chain gateways or relays that listen to on-chain access events and authorize real API access based on payment records.

### Additional Info

- Written in Clarity for Stacks blockchain
- Structured to pass Clarinet tests and static analysis checks
- Prepares foundation for decentralized developer tools and pay-per-use Web3 APIs

---


